### PR TITLE
Workaround for issue 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-This is a simple hello world program for testing git on z/OS. It's meant to be used in conjunction with [Using git for z/OS with GitHub](https://forum.rocketsoftware.com/t/using-git-for-z-os-with-github/654) on the [Rocket Community Forum](https://forum.rocketsoftware.com/categories). 
+This is a simple hello world program for testing git on z/OS. It's meant to be used in conjunction with
+[Using git for z/OS with GitHub](https://forum.rocketsoftware.com/t/using-git-for-z-os-with-github/654) 
+on the [Rocket Community Forum](https://forum.rocketsoftware.com/categories). 
 
 Here's a suggested scenario demonstrating how git can work with MVS datasets:
 


### PR DESCRIPTION
 Keep the line lengths short enough to work with an editable VB PDS.

I don't want to just increase the LRECL of the PDS because ISPF only allows editing of lines up to 255 characters long. Since [Markdown syntax](https://daringfireball.net/projects/markdown/syntax) treats consecutive lines of text as a single paragraph, this doesn't affect the presented appearance of the README.